### PR TITLE
Remove Tailwind references and fix the README links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `@yummacss/canon` - New class validator for Yumma CSS. Reports classes that are not part of the Yumma CSS canon (Tailwind habits, typos, AI hallucinations); `npx @yummacss/canon` exits with code 1 on unknown classes. Supports `--allow` for custom classes.
+- `@yummacss/canon` - New class validator for Yumma CSS. Reports classes that are not part of the Yumma CSS canon (habits from other frameworks, typos, AI hallucinations); `npx @yummacss/canon` exits with code 1 on unknown classes. Supports `--allow` for custom classes.
 - **[nitro]** Export `validateClasses` - checks class names against the same matching rules the generator uses, so a class is valid exactly when it produces CSS.
 
 ## [3.26.0] - 2026-07-02

--- a/README.md
+++ b/README.md
@@ -6,17 +6,15 @@
 of the property, initials of the value, drawn from a fixed scale rather than
 arbitrary values.
 
-There is an abbreviation table to learn — 239 utilities, and a handful of
+There is an abbreviation table to learn: 239 utilities, and a handful of
 prefixes shared between properties. What you learn is CSS: the property names
 underneath are the real ones, so the knowledge still works the day you write a
 stylesheet by hand.
 
-- [Why Yumma CSS](https://yummacss.com/docs/why-yumma-css) — and when you
-  should use something else
-- [The naming rule](https://yummacss.com/docs/naming) — including where it
-  bends
-- [Coming from Tailwind](https://yummacss.com/docs/from-tailwind)
-- [Playground](https://play.yummacss.com) — no install
+- [Installation](https://yummacss.com/docs/installation)
+- [The naming rule](https://yummacss.com/docs/naming), including where it bends
+- [Components](https://yummacss.com/ui/installation)
+- [Playground](https://play.yummacss.com), no install
 
 ## Installation
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -4,8 +4,8 @@ A utility CSS framework where every class maps to exactly one CSS property.
 
 `d-f` is `display: flex`. `jc-sb` is `justify-content: space-between`. Initials
 of the property, initials of the value, drawn from a fixed scale rather than
-arbitrary values. There is an abbreviation table to learn — see
-[the naming rule](https://yummacss.com/docs/naming) — and what you learn is
+arbitrary values. There is an abbreviation table to learn, described in
+[the naming rule](https://yummacss.com/docs/naming), and what you learn is
 CSS.
 
 ## Installation

--- a/tests/canon.test.ts
+++ b/tests/canon.test.ts
@@ -16,7 +16,7 @@ describe("validateClasses (nitro)", () => {
 		expect(valid).toHaveLength(6);
 	});
 
-	it("should reject Tailwind syntax and unknown classes", () => {
+	it("should reject unknown classes", () => {
 		const { invalid } = validateClasses(
 			["gap-4", "items-center", "flex-col", "docs-card"],
 			{},

--- a/tests/fixtures/canon-app/src/Bad.tsx
+++ b/tests/fixtures/canon-app/src/Bad.tsx
@@ -1,8 +1,8 @@
 export function Bad() {
-	const tailwindHabit = "unused-string with-hyphens";
+	const foreignClass = "unused-string with-hyphens";
 	return (
 		<div className="gap-4 items-center docs-card d-f">
-			<span className="c-white">{tailwindHabit}</span>
+			<span className="c-white">{foreignClass}</span>
 		</div>
 	);
 }


### PR DESCRIPTION
This PR removes every Tailwind mention from the repo and repoints the README links at pages that still exist.

Touches `README.md`, `packages/cli/README.md`, `CHANGELOG.md`, `tests/canon.test.ts` and one test fixture. 87 tests still pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HDxr839EhGQXKY3RwuaEDq)_