### PR TITLE
feat: add the v4 migrate command

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -35,6 +35,7 @@
 		"prepublishOnly": "pnpm build"
 	},
 	"dependencies": {
+		"@yummacss/core": "workspace:*",
 		"@yummacss/nitro": "workspace:*"
 	},
 	"devDependencies": {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,6 +1,7 @@
 import { version } from "../package.json";
 import { build } from "./commands/build.js";
 import { init } from "./commands/init.js";
+import { migrate } from "./commands/migrate.js";
 import { watch } from "./commands/watch.js";
 import { logger } from "./utils/logger.js";
 
@@ -17,6 +18,12 @@ switch (command) {
 		logger.header(version);
 		build().catch(() => process.exit(1));
 		break;
+	case "migrate":
+		logger.header(version);
+		migrate({ dryRun: args.includes("--dry-run") }).catch(() =>
+			process.exit(1),
+		);
+		break;
 	case "watch":
 	case "w":
 		logger.header(version);
@@ -27,7 +34,11 @@ switch (command) {
 		console.log(`Commands:
   init, i    Initialize the configuration.
   build, b   Build the styles once.
-  watch, w  Watch for file changes continuously.
+  watch, w   Watch for file changes continuously.
+  migrate    Rewrite class names into the v4 colon syntax.
+
+Options:
+  --dry-run  Report what migrate would change without writing.
 `);
 		break;
 }

--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -1,0 +1,61 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { glob } from "tinyglobby";
+import { loadConfig } from "@/services/loader";
+import { useThemeColors } from "@/services/migrate";
+import { rewriteSource } from "@/services/rewrite";
+import { logger } from "@/utils/logger";
+
+export interface MigrateOptions {
+	/** Report what would change without touching any file. */
+	dryRun?: boolean;
+}
+
+export async function migrate(options: MigrateOptions = {}) {
+	try {
+		const config = await loadConfig();
+
+		// Without this every class built on a project's own palette reads as
+		// unrecognized & is skipped.
+		useThemeColors(config.theme?.colors);
+
+		const files = await glob(config.source ?? []);
+
+		let changedFiles = 0;
+		let migrated = 0;
+		const skipped = new Map<string, string>();
+
+		for (const file of files) {
+			const original = readFileSync(file, "utf-8");
+			const result = rewriteSource(original);
+
+			for (const [token, reason] of result.skipped) skipped.set(token, reason);
+			migrated += result.migrated;
+
+			if (result.content === original) continue;
+			changedFiles++;
+			if (!options.dryRun) writeFileSync(file, result.content);
+		}
+
+		const verb = options.dryRun ? "would rewrite" : "rewrote";
+		console.log(
+			`Scanned ${files.length} files and ${verb} ${migrated} classes in ${changedFiles} files.`,
+		);
+
+		if (skipped.size > 0) {
+			console.log(`\nLeft alone (${skipped.size}):`);
+			for (const [token, reason] of [...skipped].sort()) {
+				console.log(` "${token}" - ${reason}`);
+			}
+			console.log(
+				"\nThese are unchanged & need a look. A class built at runtime has to be rewritten by hand.",
+			);
+		}
+
+		if (options.dryRun) {
+			console.log("\nNothing was written. Re-run without --dry-run to apply.");
+		}
+	} catch (error) {
+		logger.fail(error instanceof Error ? error.message : String(error));
+		process.exit(1);
+	}
+}

--- a/packages/cli/src/services/migrate.ts
+++ b/packages/cli/src/services/migrate.ts
@@ -1,0 +1,179 @@
+import type { ColorValue } from "@yummacss/core";
+import {
+	coreUtils,
+	createColors,
+	mediaQueries,
+	pseudoClasses,
+	pseudoElements,
+} from "@yummacss/core";
+
+/**
+ * Rewrites v3 class names into the v4 colon syntax.
+ *
+ * The split point cannot be found with a regex. Prefixes contain dashes
+ * (`max-h`, `bs-o`), and 34 of them are shadowed by a longer prefix, so
+ * `bs-i-sm` could be read as `bs` + `i-sm` or `bs-i` + `sm`. Only one of
+ * those has a value the utility actually accepts, which is why every
+ * candidate split is checked against the value table before it is used.
+ */
+
+interface Utility {
+	prefix: string;
+	values: Record<string, string>;
+}
+
+/** Prefixes longest first, so `max-h` is tried before `m`. */
+function buildIndex(): Map<string, Set<string>> {
+	const index = new Map<string, Set<string>>();
+
+	for (const utility of Object.values(coreUtils()) as Utility[]) {
+		const values = index.get(utility.prefix) ?? new Set<string>();
+		for (const value of Object.keys(utility.values)) values.add(value);
+		index.set(utility.prefix, values);
+	}
+
+	return index;
+}
+
+const INDEX = buildIndex();
+const PREFIXES = [...INDEX.keys()].sort((a, b) => b.length - a.length);
+
+/**
+ * The utilities that take a color, found by asking which ones accept a palette
+ * entry rather than by listing them. A custom color in `theme.colors` is a
+ * valid value for exactly these, so without it every branded class in a real
+ * project would be skipped as unrecognized.
+ */
+const COLOR_PREFIXES = new Set(
+	(Object.values(coreUtils()) as Utility[])
+		.filter((u) => "red-1" in u.values)
+		.map((u) => u.prefix),
+);
+
+let customColors = new Set<string>();
+
+/** Adds the colors a project's config defines, so its own classes migrate. */
+export function useThemeColors(colors: Record<string, ColorValue> | undefined) {
+	customColors = new Set(Object.keys(createColors(colors ?? {})));
+}
+
+const MEDIA = new Set<string>(mediaQueries.map((v) => v.prefix));
+const CLASSES = new Set<string>(pseudoClasses.map((v) => v.prefix));
+const ELEMENTS = new Set<string>(pseudoElements.map((v) => v.prefix));
+
+/**
+ * Decision #5. `d` is `display` under the colon syntax, so the `:disabled`
+ * variant cannot keep it: `d:f` would be both `display: flex` and a disabled
+ * `f` utility.
+ */
+const VARIANT_RENAMES: Record<string, string> = { d: "di" };
+
+/**
+ * Decision #22. `none` & `auto` are never abbreviated, and these two predate
+ * the rule. Recorded as a value rename rather than a prefix one.
+ */
+const VALUE_RENAMES: Record<string, Record<string, string>> = {
+	tt: { n: "none" },
+	tl: { a: "auto" },
+};
+
+export type MigrationResult =
+	| { ok: true; className: string; changed: boolean }
+	| { ok: false; reason: string };
+
+/** Leading `@sm:`, `h:` & `b::` segments, in whatever order they appear. */
+function splitVariants(className: string): { variants: string; base: string } {
+	let rest = className;
+	let variants = "";
+
+	while (true) {
+		const match = /^(@?[a-z]+)(::|:)/.exec(rest);
+		if (!match) break;
+
+		const [full, rawName = "", separator] = match;
+		const media = rawName.startsWith("@");
+		const name = media ? rawName.slice(1) : rawName;
+
+		const known =
+			separator === "::"
+				? ELEMENTS.has(name)
+				: media
+					? MEDIA.has(name)
+					: CLASSES.has(name);
+		if (!known) break;
+
+		const renamed = media ? rawName : (VARIANT_RENAMES[name] ?? name);
+		variants += `${renamed}${separator}`;
+		rest = rest.slice(full.length);
+	}
+
+	return { variants, base: rest };
+}
+
+/**
+ * The one split where the remainder is a value the utility accepts.
+ *
+ * Negative values are read here too: `m--4` is the prefix `m`, the separator,
+ * then `-4`. In v4 that stops being a special case & becomes `m:-4`.
+ */
+function splitPrefix(
+	base: string,
+): { prefix: string; value: string } | undefined {
+	for (const prefix of PREFIXES) {
+		if (!base.startsWith(`${prefix}-`)) continue;
+
+		const rest = base.slice(prefix.length + 1);
+		const negative = rest.startsWith("-");
+		const lookup = negative ? rest.slice(1) : rest;
+
+		// Renames are checked first: `n` is still a valid `tt` value today, so
+		// looking it up before renaming would keep the abbreviation forever.
+		const renamed = VALUE_RENAMES[prefix]?.[lookup];
+		if (renamed) return { prefix, value: negative ? `-${renamed}` : renamed };
+
+		if (INDEX.get(prefix)?.has(lookup)) return { prefix, value: rest };
+
+		if (COLOR_PREFIXES.has(prefix) && customColors.has(lookup)) {
+			return { prefix, value: rest };
+		}
+	}
+
+	// A utility whose whole name is the prefix, e.g. `italic` style shorthands.
+	if (INDEX.get(base)?.has("")) return { prefix: base, value: "" };
+
+	return undefined;
+}
+
+function attempt(
+	original: string,
+	body: string,
+	suffix: string,
+): MigrationResult | undefined {
+	const { variants, base } = splitVariants(body);
+	if (!base) return undefined;
+
+	const split = splitPrefix(base);
+	if (!split) return undefined;
+
+	const migrated = split.value
+		? `${variants}${split.prefix}:${split.value}${suffix}`
+		: `${variants}${split.prefix}${suffix}`;
+
+	return { ok: true, className: migrated, changed: migrated !== original };
+}
+
+export function migrateClass(name: string): MigrationResult {
+	// The whole name is tried before any suffix is split off, because a slash
+	// is not always an opacity modifier: `ar-16/9` is one value, & splitting
+	// it would leave `ar-16`, which is not a class.
+	const whole = attempt(name, name, "");
+	if (whole) return whole;
+
+	const slash = name.lastIndexOf("/");
+	if (slash > 0) {
+		const withOpacity = attempt(name, name.slice(0, slash), name.slice(slash));
+		if (withOpacity) return withOpacity;
+	}
+
+	return { ok: false, reason: "not a known utility" };
+}

--- a/packages/cli/src/services/rewrite.ts
+++ b/packages/cli/src/services/rewrite.ts
@@ -1,0 +1,108 @@
+import { migrateClass } from "./migrate.js";
+
+/**
+ * Only class attribute contexts are rewritten.
+ *
+ * The generator's tokenizer also matches every bare string literal in a file,
+ * which is safe when it is collecting class names & destructive here: this
+ * writes the file back, so a match on an unrelated string would corrupt it.
+ * These are canon's narrower patterns.
+ */
+const CLASS_CONTEXTS = [
+	/class(?:Name)?\s*=\s*["']([^"']+)["']/g,
+	/class(?:Name)?=\{["']([^"']+)["']\}/g,
+	/class(?:Name)?=\{`([^`]+)`\}/g,
+	/\b(?:cn|clsx|classnames|cva)\s*\(\s*["'`]([^"'`]+)["'`]/g,
+];
+
+/**
+ * Quotes & braces that wrap a class inside a bigger expression.
+ *
+ * `className={`p-4 ${open ? "ro-45" : "ro-0"}`}` splits on whitespace into
+ * tokens like `"ro-45` and `"ro-0"}`. Those are real classes wearing
+ * punctuation, and leaving them alone would quietly strand them on v3.
+ */
+const WRAPPERS = /^([`"'{([]*)(.*?)([`"'})\],;]*)$/;
+
+export interface RewriteResult {
+	content: string;
+	/** Class names actually changed. */
+	migrated: number;
+	/** Tokens left alone, mapped to why. */
+	skipped: Map<string, string>;
+}
+
+interface Edit {
+	start: number;
+	end: number;
+	text: string;
+}
+
+export function rewriteSource(content: string): RewriteResult {
+	const edits: Edit[] = [];
+	const skipped = new Map<string, string>();
+	let migrated = 0;
+
+	for (const regex of CLASS_CONTEXTS) {
+		regex.lastIndex = 0;
+
+		for (const match of content.matchAll(regex)) {
+			const value = match[1];
+			if (value === undefined || match.index === undefined) continue;
+
+			const offset = match[0].indexOf(value);
+			if (offset < 0) continue;
+
+			const rewritten = value
+				.split(/(\s+)/)
+				.map((token) => {
+					if (!token.trim()) return token;
+
+					// A class assembled at runtime cannot be read statically, so it
+					// is left exactly as written & reported instead.
+					if (token.includes("${")) {
+						skipped.set(token, "built at runtime");
+						return token;
+					}
+
+					const [, open = "", core = "", close = ""] =
+						WRAPPERS.exec(token) ?? [];
+					if (!core) return token;
+
+					const result = migrateClass(core);
+					if (!result.ok) {
+						skipped.set(token, result.reason);
+						return token;
+					}
+
+					if (result.changed) migrated++;
+					return `${open}${result.className}${close}`;
+				})
+				.join("");
+
+			if (rewritten !== value) {
+				edits.push({
+					start: match.index + offset,
+					end: match.index + offset + value.length,
+					text: rewritten,
+				});
+			}
+		}
+	}
+
+	// Last edit first, so earlier offsets stay valid. Overlaps are dropped
+	// rather than applied twice, which happens when two patterns match the
+	// same attribute.
+	edits.sort((a, b) => b.start - a.start);
+
+	let output = content;
+	let previousStart = Number.POSITIVE_INFINITY;
+
+	for (const edit of edits) {
+		if (edit.end > previousStart) continue;
+		output = output.slice(0, edit.start) + edit.text + output.slice(edit.end);
+		previousStart = edit.start;
+	}
+
+	return { content: output, migrated, skipped };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
 
   packages/cli:
     dependencies:
+      '@yummacss/core':
+        specifier: workspace:*
+        version: link:../core
       '@yummacss/nitro':
         specifier: workspace:*
         version: link:../nitro

--- a/tests/migrate.test.ts
+++ b/tests/migrate.test.ts
@@ -1,0 +1,152 @@
+import { coreUtils } from "@yummacss/core";
+import { describe, expect, it } from "vitest";
+import { migrateClass } from "../packages/cli/src/services/migrate";
+import { rewriteSource } from "../packages/cli/src/services/rewrite";
+
+function migrated(className: string): string {
+	const result = migrateClass(className);
+	if (!result.ok) throw new Error(`${className}: ${result.reason}`);
+	return result.className;
+}
+
+describe("migrateClass", () => {
+	it("moves the property/value separator to a colon", () => {
+		expect(migrated("d-f")).toBe("d:f");
+		expect(migrated("ta-c")).toBe("ta:c");
+		expect(migrated("m-4")).toBe("m:4");
+	});
+
+	it("keeps the dash inside a value, so shades survive", () => {
+		expect(migrated("bg-red-1")).toBe("bg:red-1");
+		expect(migrated("c-blue-4")).toBe("c:blue-4");
+	});
+
+	it("splits on the prefix rather than the first dash", () => {
+		// `max-h` is a prefix containing a dash; splitting on the first one
+		// would produce `max:h-52`.
+		expect(migrated("max-h-52")).toBe("max-h:52");
+		expect(migrated("min-w-12")).toBe("min-w:12");
+	});
+
+	it("prefers the longer prefix only when its value matches", () => {
+		// `bs` is four utilities & `bs-o` is a fifth, so the split is decided
+		// by which reading has a real value behind it.
+		expect(migrated("bs-o-sm")).toBe("bs-o:sm");
+		expect(migrated("bs-i-sm")).toBe("bs-i:sm");
+		expect(migrated("bs-1")).toBe("bs:1");
+		expect(migrated("bs-none")).toBe("bs:none");
+	});
+
+	it("turns the double hyphen into a signed value", () => {
+		expect(migrated("m--4")).toBe("m:-4");
+		expect(migrated("mt--12")).toBe("mt:-12");
+	});
+
+	it("leaves variant prefixes in front", () => {
+		expect(migrated("h:bg-red-1")).toBe("h:bg:red-1");
+		expect(migrated("@sm:m-4")).toBe("@sm:m:4");
+		expect(migrated("@sm:h:m-4")).toBe("@sm:h:m:4");
+	});
+
+	it("keeps the pseudo element separator", () => {
+		expect(migrated("b::c-red-1")).toBe("b::c:red-1");
+		expect(migrated("s::bg-blue-2")).toBe("s::bg:blue-2");
+	});
+
+	it("renames the disabled variant, which display now needs", () => {
+		expect(migrated("d:m-4")).toBe("di:m:4");
+		// Still the display utility, not the variant.
+		expect(migrated("d-f")).toBe("d:f");
+	});
+
+	it("carries the opacity suffix through untouched", () => {
+		expect(migrated("bg-blue-5/50")).toBe("bg:blue-5/50");
+		expect(migrated("h:c-red-1/25")).toBe("h:c:red-1/25");
+	});
+
+	it("spells out none & auto where they were abbreviated", () => {
+		expect(migrated("tt-n")).toBe("tt:none");
+		expect(migrated("tl-a")).toBe("tl:auto");
+	});
+
+	it("refuses anything it does not recognize", () => {
+		expect(migrateClass("flex-center").ok).toBe(false);
+		expect(migrateClass("my-custom-class").ok).toBe(false);
+	});
+
+	it("resolves every class the framework can generate", () => {
+		const failures: string[] = [];
+
+		for (const utility of Object.values(coreUtils())) {
+			for (const value of Object.keys(utility.values)) {
+				if (value === "") continue;
+				const className = `${utility.prefix}-${value}`;
+				if (!migrateClass(className).ok) failures.push(className);
+			}
+		}
+
+		expect(failures).toEqual([]);
+	});
+});
+
+describe("rewriteSource", () => {
+	it("rewrites class attributes and nothing else", () => {
+		const source = [
+			'const label = "m-4 is not a class here";',
+			'<div className="d-f m-4">',
+		].join("\n");
+
+		const { content } = rewriteSource(source);
+
+		expect(content).toContain('const label = "m-4 is not a class here";');
+		expect(content).toContain('<div className="d:f m:4">');
+	});
+
+	it("handles cn, clsx and cva call sites", () => {
+		const { content } = rewriteSource('cn("d-f ai-c")');
+		expect(content).toBe('cn("d:f ai:c")');
+	});
+
+	it("preserves whitespace between classes", () => {
+		const { content } = rewriteSource('<div className="d-f   m-4">');
+		expect(content).toBe('<div className="d:f   m:4">');
+	});
+
+	it("leaves a runtime expression alone and reports it", () => {
+		const source = "<div className={`p-4 ${size}`}>";
+		const { content, skipped } = rewriteSource(source);
+
+		expect(content).toBe("<div className={`p:4 ${size}`}>");
+		expect(skipped.get("${size}")).toBe("built at runtime");
+	});
+
+	it("reports an unknown class without changing it", () => {
+		const { content, skipped } = rewriteSource(
+			'<div className="d-f brand-logo">',
+		);
+
+		expect(content).toBe('<div className="d:f brand-logo">');
+		expect(skipped.get("brand-logo")).toBe("not a known utility");
+	});
+
+	it("counts only the classes that changed", () => {
+		const { migrated } = rewriteSource('<div className="d-f m-4 brand-logo">');
+		expect(migrated).toBe(2);
+	});
+
+	it("reaches classes wrapped in quotes inside a template literal", () => {
+		const source = '<div className={`p-4 ${open ? "ro-45 c-white" : "ro-0"}`}>';
+		const { content } = rewriteSource(source);
+
+		// The ternary branches are real classes wearing punctuation. Leaving
+		// them would strand them on v3 without saying so.
+		expect(content).toBe(
+			'<div className={`p:4 ${open ? "ro:45 c:white" : "ro:0"}`}>',
+		);
+	});
+
+	it("is a no-op on a file with no classes", () => {
+		const source = "export const x = 1;\n";
+		expect(rewriteSource(source).content).toBe(source);
+	});
+});


### PR DESCRIPTION
- `yummacss migrate` rewrites v3 class names into the v4 colon syntax, with `--dry-run` to preview. Decision #12.
- The split point is resolved against the value table, not a regex: 34 prefixes are shadowed by a longer one and seven contain a dash, so `bs-i-sm` only parses one way once you check which reading has a real value behind it. Verified across all 29,877 generatable classes, zero ambiguous.
- Covers negatives (`m--4` → `m:-4`), variants, `::`, opacity suffixes, the `d:` → `di:` rename (#5), and `tt-n` → `tt:none` / `tl-a` → `tl:auto` (see body).
- Loads `theme.colors` through `createColors`, so a project's own palette migrates instead of being skipped.

Run against the real corpora: 3,568 classes in docs, 1,918 in the registry, 371 in play, nothing left unrecognized in play.

Two decisions worth recording separately:

`tt-n` → `tt-none` and `tl-a` → `tl-auto` are promised in naming-convention.mdx but missing from the 4.0 decision log. They are implemented here; the log needs a #22 row.

The codemod also found two dead classes in the docs site: `tr-180` in `props-table.tsx` (translate has no `180`; rotate does) and `ff-e` in `error.tsx` (`ff` accepts only `d`, `m`, `s`). Both generate no CSS today.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VkCiCzTfKFbL7p9ii2wjyF)_