### PR TITLE
Release 3.30.0

### DIFF
--- a/packages/nitro/src/scan.ts
+++ b/packages/nitro/src/scan.ts
@@ -38,7 +38,7 @@ export async function scan(
 	for (const file of files) {
 		try {
 			const content = readFileSync(file, "utf-8");
-			const tokens = tokenizer(content);
+			const tokens = tokenizer(content, file);
 			tokens.forEach((token) => {
 				classes.add(token);
 			});

--- a/packages/nitro/src/tokenizer.ts
+++ b/packages/nitro/src/tokenizer.ts
@@ -1,62 +1,240 @@
-export function tokenizer(content: string): string[] {
-	const tokens = new Set<string>();
+/**
+ * Class extraction.
+ *
+ * This used to be a list of regexes, one of which matched every bare string
+ * literal as `/"([^"]+)"/g`. `[^"]+` is one-or-more, so an empty literal `""`
+ * could not match: the regex backtracked and began its next match on the
+ * *second* quote of that pair, and from there it captured the code between
+ * strings rather than the strings. Every later class in the file was lost
+ * until another `""` re-synced the pairing, which is why classes from the same
+ * string literal disagreed with each other and why "position in the file"
+ * looked like it mattered. A regex literal or a quote inside a comment did the
+ * same thing.
+ *
+ * Pairing quotes without knowing what a string is cannot be made correct, so
+ * this lexes instead. JavaScript-family files get a real scanner that knows
+ * about comments, escapes, template literals and regex literals. Everything
+ * else - `.mdx` above all, which is not JavaScript and where a lone apostrophe
+ * in prose is normal - gets a line-scoped pass, so a stray quote can only cost
+ * the rest of its own line instead of the rest of the file.
+ */
 
-	// generic class attributes
-	const classRegexes = [
-		/class(?:Name)?=["']([^"']+)["']/g,
-		/class(?:Name)?=\{["']([^"']+)["']\}/g,
-		/class(?:Name)?=\{`([^`]+)`\}/g,
-	];
+const JS_EXTENSIONS = /\.(?:[cm]?[jt]sx?)$/;
 
-	// template literals
-	const templateRegexes = [/`([^`]+)`/g, /"([^"]+)"/g, /'([^']+)'/g];
+/** A `/` here opens a regex literal rather than dividing. */
+const REGEX_ALLOWED_BEFORE = new Set([
+	"=",
+	"(",
+	",",
+	":",
+	"[",
+	"!",
+	"&",
+	"|",
+	"?",
+	"{",
+	"}",
+	";",
+	"\n",
+	"+",
+	"-",
+	"*",
+	"%",
+	"<",
+	">",
+	"~",
+	"^",
+]);
 
-	// cva (class variance authority)
-	const cvaRegexes = [
-		/cva\s*\(\s*["'`]([^"'`]+)["'`]/g,
-		/:\s*["'`]([^"'`]+)["'`]/g,
-	];
+/** Punctuation that no class name contains, so a token carrying it is debris. */
+const NOT_IN_A_CLASS = /[<>"'`=(){};,\\]/;
 
-	// cn utility
-	const cnRegexes = [
-		/\bcn\s*\(\s*["'`]([^"'`]+)["'`]/g,
-		/\bcn\s*\(\s*\{\s*["'`]([^"'`]+)["'`]\s*:/g,
-	];
+function addClasses(source: string, into: Set<string>): void {
+	for (const raw of source.split(/\s+/)) {
+		if (!raw || NOT_IN_A_CLASS.test(raw)) continue;
+		const clean = raw.replace(/^@+/, "");
+		if (clean && /^[a-z]/.test(clean) && clean.includes("-")) into.add(raw);
+	}
+}
 
-	// clsx and classnames
-	const clsxRegexes = [
-		/clsx\s*\(\s*["'`]([^"'`]+)["'`]/g,
-		/classnames\s*\(\s*["'`]([^"'`]+)["'`]/g,
-		/clsx\s*\(\s*\{\s*["'`]([^"'`]+)["'`]\s*:/g,
-		/classnames\s*\(\s*\{\s*["'`]([^"'`]+)["'`]\s*:/g,
-	];
+/**
+ * Lexes JavaScript, TypeScript and JSX, emitting the contents of every string
+ * literal and every static chunk of every template literal. Comments and regex
+ * literals are skipped rather than read, which is the whole point: most of the
+ * class-shaped debris the old regexes collected (`biome-ignore`, `hand-written`,
+ * and prose like `m-23` out of a sentence about the scale) lived in comments.
+ */
+function lexJs(content: string, into: Set<string>): void {
+	const n = content.length;
+	// Depth of `${}` interpolations, so a `}` knows whether it closes one.
+	const templateStack: number[] = [];
+	let i = 0;
+	let lastSignificant = "\n";
 
-	const allRegexes = [
-		...classRegexes,
-		...templateRegexes,
-		...cvaRegexes,
-		...cnRegexes,
-		...clsxRegexes,
-	];
+	while (i < n) {
+		const c = content[i];
 
-	for (const regex of allRegexes) {
-		let match: RegExpExecArray | null;
-		match = regex.exec(content);
-		while (match !== null) {
-			const classString = match[1];
-			if (classString) {
-				const individualClasses = classString.split(/\s+/).filter((cls) => {
-					const clean = cls.replace(/^@+/, "");
-					return clean && /^[a-z]/.test(clean) && clean.includes("-");
-				});
+		// Comments.
+		if (c === "/" && content[i + 1] === "/") {
+			while (i < n && content[i] !== "\n") i++;
+			continue;
+		}
+		if (c === "/" && content[i + 1] === "*") {
+			i += 2;
+			while (i < n && !(content[i] === "*" && content[i + 1] === "/")) i++;
+			i += 2;
+			continue;
+		}
 
-				individualClasses.forEach((cls) => {
-					tokens.add(cls);
-				});
+		// Regex literal. Only where a value cannot already have ended, otherwise
+		// this is division and skipping to the next `/` would swallow real code.
+		if (c === "/" && REGEX_ALLOWED_BEFORE.has(lastSignificant)) {
+			i++;
+			let inClass = false;
+			while (i < n) {
+				const r = content[i];
+				if (r === "\\") {
+					i += 2;
+					continue;
+				}
+				if (r === "[") inClass = true;
+				else if (r === "]") inClass = false;
+				else if (r === "/" && !inClass) {
+					i++;
+					break;
+				} else if (r === "\n") break;
+				i++;
 			}
-			match = regex.exec(content);
+			lastSignificant = "/";
+			continue;
+		}
+
+		// Quoted strings.
+		if (c === '"' || c === "'") {
+			const quote = c;
+			let value = "";
+			i++;
+			while (i < n) {
+				const s = content[i];
+				if (s === "\\") {
+					value += content[i + 1] ?? "";
+					i += 2;
+					continue;
+				}
+				if (s === quote) {
+					i++;
+					break;
+				}
+				if (s === "\n") break;
+				value += s;
+				i++;
+			}
+			addClasses(value, into);
+			lastSignificant = quote;
+			continue;
+		}
+
+		// Template literals. Static chunks are classes; `${}` returns to code,
+		// so strings nested inside an interpolation are found by this same loop.
+		if (c === "`") {
+			let value = "";
+			i++;
+			while (i < n) {
+				const t = content[i];
+				if (t === "\\") {
+					value += content[i + 1] ?? "";
+					i += 2;
+					continue;
+				}
+				if (t === "`") {
+					i++;
+					break;
+				}
+				if (t === "$" && content[i + 1] === "{") {
+					addClasses(value, into);
+					value = "";
+					templateStack.push(0);
+					i += 2;
+					break;
+				}
+				value += t;
+				i++;
+			}
+			addClasses(value, into);
+			lastSignificant = "`";
+			continue;
+		}
+
+		if (templateStack.length > 0) {
+			if (c === "{") templateStack[templateStack.length - 1]++;
+			else if (c === "}") {
+				if (templateStack[templateStack.length - 1] === 0) {
+					// Closes the interpolation; resume the template literal.
+					templateStack.pop();
+					let value = "";
+					i++;
+					while (i < n) {
+						const t = content[i];
+						if (t === "\\") {
+							value += content[i + 1] ?? "";
+							i += 2;
+							continue;
+						}
+						if (t === "`") {
+							i++;
+							break;
+						}
+						if (t === "$" && content[i + 1] === "{") {
+							addClasses(value, into);
+							value = "";
+							templateStack.push(0);
+							i += 2;
+							break;
+						}
+						value += t;
+						i++;
+					}
+					addClasses(value, into);
+					lastSignificant = "`";
+					continue;
+				}
+				templateStack[templateStack.length - 1]--;
+			}
+		}
+
+		if (!/\s/.test(c)) lastSignificant = c;
+		else if (c === "\n") lastSignificant = "\n";
+		i++;
+	}
+}
+
+const CLASS_ATTR =
+	/class(?:Name)?\s*=\s*(?:"([^"]*)"|'([^']*)'|\{?`([^`]*)`\}?)/g;
+const QUOTED = /"([^"]*)"|'([^']*)'|`([^`]*)`/g;
+
+/**
+ * Everything that is not JavaScript, `.mdx` chiefly. Each line is scanned on
+ * its own so an unbalanced quote - an apostrophe in a sentence, a lone backtick
+ * opening a fence - costs that line and nothing after it.
+ */
+function lexGeneric(content: string, into: Set<string>): void {
+	for (const line of content.split("\n")) {
+		for (const m of line.matchAll(CLASS_ATTR)) {
+			addClasses(m[1] ?? m[2] ?? m[3] ?? "", into);
+		}
+		for (const m of line.matchAll(QUOTED)) {
+			addClasses(m[1] ?? m[2] ?? m[3] ?? "", into);
 		}
 	}
+}
 
+/**
+ * @param filename Used only to choose a strategy. Omitted means the
+ * conservative line-scoped pass, which is correct for any input.
+ */
+export function tokenizer(content: string, filename?: string): string[] {
+	const tokens = new Set<string>();
+	if (filename && JS_EXTENSIONS.test(filename)) lexJs(content, tokens);
+	else lexGeneric(content, tokens);
 	return Array.from(tokens);
 }

--- a/tests/tokenizer.test.ts
+++ b/tests/tokenizer.test.ts
@@ -1,0 +1,190 @@
+import { tokenizer } from "@yummacss/nitro/browser";
+import { describe, expect, it } from "vitest";
+
+const classes = (source: string, filename = "file.tsx") =>
+	tokenizer(source, filename);
+
+describe("Tokenizer", () => {
+	describe("quote pairing", () => {
+		// The bug this file exists for. `[^"]+` could not match `""`, so the old
+		// regex began its next match on the second quote of the pair and captured
+		// the code between strings from there on. Everything after an odd number
+		// of empty literals was silently lost.
+		it("does not lose classes after an empty string literal", () => {
+			const found = classes(
+				`const a = ["p-4", flag ? "g-2" : "", "m-8"].filter(Boolean);`,
+			);
+			expect(found).toContain("p-4");
+			expect(found).toContain("g-2");
+			expect(found).toContain("m-8");
+		});
+
+		it("survives many empty literals, odd and even", () => {
+			const found = classes(`
+				const rootClasses = [
+					"d-f fd-c w-100% max-w-96",
+					bordered ? "g-2" : "",
+					subtle ? "br-lg" : "",
+					ghost ? "blw-2 pl-4" : "",
+					isOpen ? "blc-indigo-5" : "blc-silver-3",
+				].filter(Boolean).join(" ");
+			`);
+			for (const c of [
+				"d-f",
+				"max-w-96",
+				"g-2",
+				"br-lg",
+				"blw-2",
+				"blc-indigo-5",
+				"blc-silver-3",
+			]) {
+				expect(found).toContain(c);
+			}
+		});
+
+		// A regex literal holds an odd number of quotes, which desynced every
+		// pairing below it. `code-decorate.mjs` contained this exact line and
+		// nothing under it was scanned.
+		it("is not blinded by a regex literal containing quotes", () => {
+			const found = classes(`
+				const meta = /"([^"]+)"/g;
+				const LINE_CLASSES = "d-b mx--4 px-4";
+			`);
+			expect(found).toContain("d-b");
+			expect(found).toContain("mx--4");
+			expect(found).toContain("px-4");
+		});
+
+		it("still reads a division as division", () => {
+			const found = classes(`const half = total / 2;\nconst c = "p-4";`);
+			expect(found).toContain("p-4");
+		});
+
+		it("handles escaped quotes inside a string", () => {
+			const found = classes(`const a = "say \\"hi\\"";\nconst b = "m-2";`);
+			expect(found).toContain("m-2");
+		});
+	});
+
+	describe("comments", () => {
+		it("is not desynced by a quote in a line comment", () => {
+			const found = classes(`
+				// the reader's own copy
+				const a = "p-6";
+			`);
+			expect(found).toContain("p-6");
+		});
+
+		it("is not desynced by quotes in a block comment", () => {
+			const found = classes(`
+				/** e.g. \`"@sm:d-b" "@md:d-b"\` returns ["@sm:d-b"] */
+				const a = "g-3";
+			`);
+			expect(found).toContain("g-3");
+		});
+
+		// Prose that talks about classes is not markup that uses them. The old
+		// tokenizer generated real CSS for `m-23` because a comment mentioned it.
+		it("does not collect class names out of comments", () => {
+			const found = classes(`
+				// a header reading \`m-4 m-8 m-12\` suggests m-23 is not a class
+				/** Commented-out markup: <div className="d-none" /> */
+				const a = "p-2";
+			`);
+			expect(found).toContain("p-2");
+			for (const c of ["m-4", "m-8", "m-12", "m-23", "d-none"]) {
+				expect(found).not.toContain(c);
+			}
+		});
+	});
+
+	describe("template literals", () => {
+		it("reads static chunks and nested strings across interpolations", () => {
+			const found = classes(
+				'const c = `d-f ai-c ${open ? "o-100" : "o-0"} px-1 ${big ? "w-8" : "w-4"} tp-a`;',
+			);
+			for (const c of [
+				"d-f",
+				"ai-c",
+				"o-100",
+				"o-0",
+				"px-1",
+				"w-8",
+				"w-4",
+				"tp-a",
+			]) {
+				expect(found).toContain(c);
+			}
+		});
+
+		it("does not emit fragments of surrounding syntax", () => {
+			const found = classes('<div className={`d-f ${x ? "o-60" : ""}`} />');
+			expect(found).toContain("d-f");
+			expect(found).toContain("o-60");
+			for (const token of found) {
+				expect(token).not.toMatch(/[<>"'`={}();,]/);
+			}
+		});
+
+		it("handles a nested object inside an interpolation", () => {
+			const found = classes(
+				'const c = `p-4 ${map[{ a: 1 }.a] ? "bg-red" : "bg-blue"} m-2`;',
+			);
+			expect(found).toContain("p-4");
+			expect(found).toContain("bg-red");
+			expect(found).toContain("m-2");
+		});
+	});
+
+	describe("class attributes", () => {
+		it("reads class and className, quoted and braced", () => {
+			const found = classes(`
+				<a class="c-blue" />
+				<b className="d-b" />
+				<c className={"g-2"} />
+			`);
+			expect(found).toEqual(expect.arrayContaining(["c-blue", "d-b", "g-2"]));
+		});
+
+		it("keeps variant and opacity syntax intact", () => {
+			const found = classes(
+				`<div className="@sm:d-b h:bg-red/50 fv:oo-2 mx--4 bg-accent-dim/10" />`,
+			);
+			for (const c of [
+				"@sm:d-b",
+				"h:bg-red/50",
+				"fv:oo-2",
+				"mx--4",
+				"bg-accent-dim/10",
+			]) {
+				expect(found).toContain(c);
+			}
+		});
+	});
+
+	describe("non-JavaScript input", () => {
+		// `.mdx` is prose. A lone apostrophe is normal there, and must not cost
+		// anything past its own line.
+		it("bounds an unbalanced quote to its own line", () => {
+			const found = classes(
+				`Here's a paragraph about it.\n\n<div className="d-g gtc-12" />\n`,
+				"page.mdx",
+			);
+			expect(found).toContain("d-g");
+			expect(found).toContain("gtc-12");
+		});
+
+		it("reads classes out of a fenced example", () => {
+			const found = classes(
+				'```jsx\n<div className="cs-ld ta-c">Hello</div>\n```\n',
+				"page.mdx",
+			);
+			expect(found).toContain("cs-ld");
+			expect(found).toContain("ta-c");
+		});
+
+		it("defaults to the safe path when no filename is given", () => {
+			expect(tokenizer(`<div class="p-4" />`)).toContain("p-4");
+		});
+	});
+});


### PR DESCRIPTION
Two `nitro` correctness fixes plus the release prep. Minor rather than patch: both change which CSS gets generated, and `tokenizer` gains an optional parameter.

**Scanner.** It paired quotes with regexes, so an empty literal `""` desynced every class after it in a file. Now a lexer — JS files get one that tracks comments, escapes, template literals and regex literals; `.mdx` gets a line-scoped pass. 1579 tokens before, 1262 after; the 9 classes no longer found are all in comments.

**Negatives.** A leading `-` was applied with no notion of whether the property accepts one, so 72 utilities emitted CSS the parser discards (`w--1` → `width: -.25rem`). It was also *ignored* on non-numeric values, making `m--auto` a silent alias of `m-auto`. Now meaningful only where the property and the value both allow it. The 40 legal utilities are unchanged.

`yummacss migrate` is unwired from the CLI: it writes v4 colon syntax that this release cannot compile. Re-wire it with v4.

150 tests, build green. Checked against docs, ui and play — no class they use stops generating.

Context in `docs/NOTES.md`, Phases 1 and 2.