### PR TITLE
pnpm in every README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ```bash
 pnpm add yummacss -D
-pnpx yummacss init
+pnpm dlx yummacss init
 ```
 
 ## Documentation

--- a/packages/canon/README.md
+++ b/packages/canon/README.md
@@ -5,13 +5,13 @@ Class validator for [Yumma CSS](https://yummacss.com). Reports every class that 
 ## Installation
 
 ```bash
-npm install -D @yummacss/canon
+pnpm add -D @yummacss/canon
 ```
 
 ## Usage
 
 ```bash
-npx @yummacss/canon
+pnpm dlx @yummacss/canon
 ```
 
 Validates against the Yumma CSS generator itself. Variants, opacity, negative values, custom theme colors, prefixes, and safelist entries are all understood.
@@ -19,7 +19,7 @@ Validates against the Yumma CSS generator itself. Variants, opacity, negative va
 Skip custom classes with `--allow`:
 
 ```bash
-npx @yummacss/canon --allow "docs-container,brand-logo"
+pnpm dlx @yummacss/canon --allow "docs-container,brand-logo"
 ```
 
 ## API

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -11,8 +11,8 @@ CSS.
 ## Installation
 
 ```bash
-npm install yummacss -D
-npx yummacss init
+pnpm add yummacss -D
+pnpm dlx yummacss init
 ```
 
 ## Commands

--- a/packages/postcss/README.md
+++ b/packages/postcss/README.md
@@ -5,7 +5,7 @@ PostCSS plugin for [Yumma CSS](https://yummacss.com).
 ## Installation
 
 ```bash
-npm install -D @yummacss/postcss
+pnpm add -D @yummacss/postcss
 ```
 
 ## Usage

--- a/packages/vite/README.md
+++ b/packages/vite/README.md
@@ -5,7 +5,7 @@ Vite plugin for [Yumma CSS](https://yummacss.com).
 ## Installation
 
 ```bash
-npm install -D @yummacss/vite
+pnpm add -D @yummacss/vite
 ```
 
 ## Usage


### PR DESCRIPTION
Root README plus `canon`, `cli`, `postcss` and `vite`.

**Correction:** an earlier version of this description said `pnpx` was "never a real command". That's wrong — `bin/pnpx.cjs` ships with pnpm as a four-line alias for `pnpm dlx`, with no deprecation warning, verified on 10.33. `pnpx yummacss init` in the root README worked. It still moves to `pnpm dlx` because that's what pnpm's own help calls canonical, but as a style choice, not a fix.

**Left as written:** `CHANGELOG.md` line 108 still says `npx @yummacss/canon`. That entry records what shipped in that release; rewriting its commands would misreport the past.

150 tests pass.