### PR TITLE
Turn off the Claude attribution trailers

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  }
+}


### PR DESCRIPTION
Adds `.claude/settings.json` so commits and PR descriptions stop carrying `Co-Authored-By`, `Claude-Session` and the generated-with footer.

An empty string hides the attribution. The CLI's own description for `commit` is "including any trailers", so both trailers go together. `includeCoAuthoredBy` does the same job but the schema marks it deprecated in favour of this.

Committed rather than left in a home directory because web sessions run in a container that is wiped afterwards, so only the repo copy survives.

Does not touch `merge-perf`, which still carries the unmerged 3.31.1 perf fix.