### PR TITLE
Include outline-color in the colors transition group

### DIFF
--- a/packages/core/src/utilities/transition.ts
+++ b/packages/core/src/utilities/transition.ts
@@ -26,7 +26,7 @@ export const transition: Utilities = {
 		values: {
 			a: "all",
 			bs: "box-shadow",
-			c: "color, background-color, border-color, text-decoration-color, fill, stroke",
+			c: "color, background-color, border-color, outline-color, text-decoration-color, fill, stroke",
 			d: "height, width",
 			h: "height",
 			none: "none",


### PR DESCRIPTION
**`tp-c`.** Adds `outline-color` to the property list, so a focus ring can transition.

`tsc` clean, 158 tests passing.